### PR TITLE
feat(be): Add ChatRoom REST API

### DIFF
--- a/docs/api-specification.yaml
+++ b/docs/api-specification.yaml
@@ -48,7 +48,7 @@ components:
         - role
       properties:
         role:
-          $ref: '#/components/schemas/UserRole'
+          $ref: "#/components/schemas/UserRole"
 
     LoginResponse:
       type: object
@@ -85,7 +85,7 @@ components:
           nullable: true
           description: 프로필 이미지 URL
         role:
-          $ref: '#/components/schemas/UserRole'
+          $ref: "#/components/schemas/UserRole"
         location:
           type: string
           nullable: true
@@ -119,7 +119,7 @@ components:
           format: uri
           nullable: true
         role:
-          $ref: '#/components/schemas/UserRole'
+          $ref: "#/components/schemas/UserRole"
 
     UserUpdateRequest:
       type: object
@@ -262,10 +262,10 @@ components:
           format: int64
           description: 평가 고유 식별자
         user:
-          $ref: '#/components/schemas/UserResponse'
+          $ref: "#/components/schemas/UserResponse"
           description: 평가를 남긴 사용자
         targetType:
-          $ref: '#/components/schemas/RateTargetType'
+          $ref: "#/components/schemas/RateTargetType"
         targetId:
           type: integer
           format: int64
@@ -325,7 +325,7 @@ components:
         ratings:
           type: array
           items:
-            $ref: '#/components/schemas/RateResponse'
+            $ref: "#/components/schemas/RateResponse"
 
   securitySchemes:
     BearerAuth:
@@ -353,20 +353,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UserRoleUpdateRequest'
+              $ref: "#/components/schemas/UserRoleUpdateRequest"
       responses:
-        '200':
+        "200":
           description: 역할 선택 및 로그인 성공
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
+                  - $ref: "#/components/schemas/ApiResponse"
                   - type: object
                     properties:
                       data:
-                        $ref: '#/components/schemas/LoginResponse'
-        '401':
+                        $ref: "#/components/schemas/LoginResponse"
+        "401":
           description: 인증 실패 (유효하지 않은 registerToken)
 
   /api/auth/logout:
@@ -378,12 +378,12 @@ paths:
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: 로그아웃 성공
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponse'
+                $ref: "#/components/schemas/ApiResponse"
 
   /api/auth/refresh:
     post:
@@ -393,18 +393,18 @@ paths:
       description: 쿠키에 담긴 Refresh Token을 사용하여 만료된 Access Token을 재발급합니다.
       security: []
       responses:
-        '200':
+        "200":
           description: 토큰 재발급 성공
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
+                  - $ref: "#/components/schemas/ApiResponse"
                   - type: object
                     properties:
                       data:
-                        $ref: '#/components/schemas/AccessTokenResponse'
-        '401':
+                        $ref: "#/components/schemas/AccessTokenResponse"
+        "401":
           description: 유효하지 않은 Refresh Token
 
   # ===================
@@ -419,17 +419,17 @@ paths:
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: 내 정보 조회 성공
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
+                  - $ref: "#/components/schemas/ApiResponse"
                   - type: object
                     properties:
                       data:
-                        $ref: '#/components/schemas/UserResponse'
+                        $ref: "#/components/schemas/UserResponse"
     patch:
       tags:
         - users
@@ -442,19 +442,19 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UserUpdateRequest'
+              $ref: "#/components/schemas/UserUpdateRequest"
       responses:
-        '200':
+        "200":
           description: 프로필 수정 성공
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
+                  - $ref: "#/components/schemas/ApiResponse"
                   - type: object
                     properties:
                       data:
-                        $ref: '#/components/schemas/UserResponse'
+                        $ref: "#/components/schemas/UserResponse"
     delete:
       tags:
         - users
@@ -463,12 +463,12 @@ paths:
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: 회원 탈퇴 성공
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponse'
+                $ref: "#/components/schemas/ApiResponse"
 
   # ===================
   # AI Chat Domain APIs
@@ -488,19 +488,19 @@ paths:
             format: int64
           description: 사용자 ID
       responses:
-        '200':
+        "200":
           description: 세션 목록 조회 성공
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
+                  - $ref: "#/components/schemas/ApiResponse"
                   - type: object
                     properties:
                       data:
                         type: array
                         items:
-                          $ref: '#/components/schemas/SessionsResponse'
+                          $ref: "#/components/schemas/SessionsResponse"
 
     post:
       tags:
@@ -516,17 +516,17 @@ paths:
             format: int64
           description: 사용자 ID
       responses:
-        '200':
+        "200":
           description: 세션 생성 성공
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
+                  - $ref: "#/components/schemas/ApiResponse"
                   - type: object
                     properties:
                       data:
-                        $ref: '#/components/schemas/SessionsResponse'
+                        $ref: "#/components/schemas/SessionsResponse"
 
   /api/aichat/sessions/{sessionId}:
     delete:
@@ -550,13 +550,13 @@ paths:
             format: int64
           description: 사용자 ID
       responses:
-        '200':
+        "200":
           description: 세션 삭제 완료
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponse'
-        '404':
+                $ref: "#/components/schemas/ApiResponse"
+        "404":
           description: 세션을 찾을 수 없음
 
   /api/aichat/sessions/{sessionId}/messages:
@@ -581,19 +581,19 @@ paths:
             format: int64
           description: 사용자 ID
       responses:
-        '200':
+        "200":
           description: 채팅 기록 조회 성공
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
+                  - $ref: "#/components/schemas/ApiResponse"
                   - type: object
                     properties:
                       data:
                         type: array
                         items:
-                          $ref: '#/components/schemas/SessionMessagesResponse'
+                          $ref: "#/components/schemas/SessionMessagesResponse"
 
     post:
       tags:
@@ -628,17 +628,17 @@ paths:
                   type: string
                   description: 사용자 메시지 내용
       responses:
-        '200':
+        "200":
           description: 메시지 전송 및 AI 응답 완료
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
+                  - $ref: "#/components/schemas/ApiResponse"
                   - type: object
                     properties:
                       data:
-                        $ref: '#/components/schemas/AiChatResponse'
+                        $ref: "#/components/schemas/AiChatResponse"
 
   /api/aichat/sessions/{sessionId}/title:
     patch:
@@ -675,20 +675,20 @@ paths:
                   maxLength: 100
                   description: 새로운 세션 제목
       responses:
-        '200':
+        "200":
           description: 제목 수정 성공
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
+                  - $ref: "#/components/schemas/ApiResponse"
                   - type: object
                     properties:
                       data:
-                        $ref: '#/components/schemas/UpdateSessionTitleResponse'
-        '404':
+                        $ref: "#/components/schemas/UpdateSessionTitleResponse"
+        "404":
           description: 세션을 찾을 수 없음
-        '403':
+        "403":
           description: 권한 없음
 
   # ===================
@@ -720,13 +720,13 @@ paths:
             type: string
           description: "커서 기반 페이지네이션 포인터. '{updatedAt ISO-8601}|{roomId}' 형식이며 이전 응답의 nextCursor를 그대로 전달합니다."
       responses:
-        '200':
+        "200":
           description: 채팅방 목록 조회 성공
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
+                  - $ref: "#/components/schemas/ApiResponse"
                   - type: object
                     properties:
                       data:
@@ -735,7 +735,7 @@ paths:
                           rooms:
                             type: array
                             items:
-                              $ref: '#/components/schemas/ChatRoomResponse'
+                              $ref: "#/components/schemas/ChatRoomResponse"
                           nextCursor:
                             type: string
                             nullable: true
@@ -754,20 +754,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ChatRoomStartRequest'
+              $ref: "#/components/schemas/ChatRoomStartRequest"
       responses:
-        '200':
+        "200":
           description: 채팅방 생성 또는 기존 방 반환
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
+                  - $ref: "#/components/schemas/ApiResponse"
                   - type: object
                     properties:
                       data:
-                        $ref: '#/components/schemas/ChatRoomResponse'
-        '403':
+                        $ref: "#/components/schemas/ChatRoomResponse"
+        "403":
           description: 인증되지 않은 사용자 또는 참여자가 아닙니다.
 
   /api/userchat/rooms/{roomId}:
@@ -787,20 +787,20 @@ paths:
             format: int64
           description: 채팅방 ID
       responses:
-        '200':
+        "200":
           description: 채팅방 조회 성공
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
+                  - $ref: "#/components/schemas/ApiResponse"
                   - type: object
                     properties:
                       data:
-                        $ref: '#/components/schemas/ChatRoomResponse'
-        '403':
+                        $ref: "#/components/schemas/ChatRoomResponse"
+        "403":
           description: 채팅방 참여자가 아닙니다.
-        '404':
+        "404":
           description: 채팅방을 찾을 수 없음
 
     delete:
@@ -819,15 +819,15 @@ paths:
             format: int64
           description: 채팅방 ID
       responses:
-        '200':
+        "200":
           description: 채팅방 삭제 완료
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponse'
-        '403':
+                $ref: "#/components/schemas/ApiResponse"
+        "403":
           description: 채팅방 생성자가 아닙니다.
-        '404':
+        "404":
           description: 채팅방을 찾을 수 없음
 
   /api/userchat/rooms/{roomId}/messages:
@@ -864,22 +864,22 @@ paths:
             maximum: 200
           description: 최대 조회 건수 (기본 50)
       responses:
-        '200':
+        "200":
           description: 메시지 조회 성공
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
+                  - $ref: "#/components/schemas/ApiResponse"
                   - type: object
                     properties:
                       data:
                         type: array
                         items:
-                          $ref: '#/components/schemas/ChatMessageResponse'
-        '403':
+                          $ref: "#/components/schemas/ChatMessageResponse"
+        "403":
           description: 채팅방 참여자가 아닙니다.
-        '404':
+        "404":
           description: 채팅방을 찾을 수 없음
 
     post:
@@ -902,22 +902,22 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ChatMessageSendRequest'
+              $ref: "#/components/schemas/ChatMessageSendRequest"
       responses:
-        '201':
+        "201":
           description: 메시지 전송 성공
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
+                  - $ref: "#/components/schemas/ApiResponse"
                   - type: object
                     properties:
                       data:
-                        $ref: '#/components/schemas/ChatMessageResponse'
-        '403':
+                        $ref: "#/components/schemas/ChatMessageResponse"
+        "403":
           description: 채팅방 참여자가 아닙니다.
-        '404':
+        "404":
           description: 채팅방을 찾을 수 없음
 
   # ===================
@@ -944,19 +944,19 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RateRequest'
+              $ref: "#/components/schemas/RateRequest"
       responses:
-        '200':
+        "200":
           description: 평가 성공
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
+                  - $ref: "#/components/schemas/ApiResponse"
                   - type: object
                     properties:
                       data:
-                        $ref: '#/components/schemas/RateResponse'
+                        $ref: "#/components/schemas/RateResponse"
 
   /api/rate/aichat/sessions/{sessionId}:
     put:
@@ -979,19 +979,19 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RateRequest'
+              $ref: "#/components/schemas/RateRequest"
       responses:
-        '200':
+        "200":
           description: 평가 성공
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
+                  - $ref: "#/components/schemas/ApiResponse"
                   - type: object
                     properties:
                       data:
-                        $ref: '#/components/schemas/RateResponse'
+                        $ref: "#/components/schemas/RateResponse"
 
   /api/rate/guides/my:
     get:
@@ -1002,17 +1002,17 @@ paths:
       security:
         - BearerAuth: []
       responses:
-        '200':
+        "200":
           description: 내 평가 목록 조회 성공
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
+                  - $ref: "#/components/schemas/ApiResponse"
                   - type: object
                     properties:
                       data:
-                        $ref: '#/components/schemas/GuideRatingSummaryResponse'
+                        $ref: "#/components/schemas/GuideRatingSummaryResponse"
 
   /api/rate/admin/aichat/sessions:
     get:
@@ -1039,20 +1039,17 @@ paths:
           name: sort
           schema:
             type: string
-            description: '정렬 기준 (예: createdAt,desc)'
+            description: "정렬 기준 (예: createdAt,desc)"
       responses:
-        '200':
+        "200":
           description: AI 채팅 평가 목록 조회 성공
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/ApiResponse'
+                  - $ref: "#/components/schemas/ApiResponse"
                   - type: object
                     properties:
                       data:
                         type: object
                         description: Page<RateResponse> 형태
-
-
-

--- a/src/main/kotlin/com/back/koreaTravelGuide/domain/userChat/chatroom/controller/ChatRoomController.kt
+++ b/src/main/kotlin/com/back/koreaTravelGuide/domain/userChat/chatroom/controller/ChatRoomController.kt
@@ -1,6 +1,7 @@
 package com.back.koreaTravelGuide.domain.userChat.chatroom.controller
 
 import com.back.koreaTravelGuide.common.ApiResponse
+import com.back.koreaTravelGuide.domain.userChat.chatroom.dto.ChatRoomListResponse
 import com.back.koreaTravelGuide.domain.userChat.chatroom.dto.ChatRoomResponse
 import com.back.koreaTravelGuide.domain.userChat.chatroom.dto.ChatRoomStartRequest
 import com.back.koreaTravelGuide.domain.userChat.chatroom.service.ChatRoomService
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -20,6 +22,18 @@ import org.springframework.web.bind.annotation.RestController
 class ChatRoomController(
     private val roomService: ChatRoomService,
 ) {
+    @GetMapping
+    fun listRooms(
+        @AuthenticationPrincipal requesterId: Long?,
+        @RequestParam(required = false, defaultValue = "20") limit: Int,
+        @RequestParam(required = false) cursor: String?,
+    ): ResponseEntity<ApiResponse<ChatRoomListResponse>> {
+        val authenticatedId = requesterId ?: throw AccessDeniedException("인증이 필요합니다.")
+        val safeLimit = limit.coerceIn(1, 100)
+        val response = roomService.listRooms(authenticatedId, safeLimit, cursor)
+        return ResponseEntity.ok(ApiResponse(msg = "채팅방 목록 조회", data = response))
+    }
+
     // 같은 페어는 방 재사용
     @PostMapping("/start")
     fun startChat(

--- a/src/main/kotlin/com/back/koreaTravelGuide/domain/userChat/chatroom/dto/ChatRoomListResponse.kt
+++ b/src/main/kotlin/com/back/koreaTravelGuide/domain/userChat/chatroom/dto/ChatRoomListResponse.kt
@@ -1,0 +1,6 @@
+package com.back.koreaTravelGuide.domain.userChat.chatroom.dto
+
+data class ChatRoomListResponse(
+    val rooms: List<ChatRoomResponse>,
+    val nextCursor: String?,
+)

--- a/src/main/kotlin/com/back/koreaTravelGuide/domain/userChat/chatroom/repository/ChatRoomRepository.kt
+++ b/src/main/kotlin/com/back/koreaTravelGuide/domain/userChat/chatroom/repository/ChatRoomRepository.kt
@@ -1,8 +1,10 @@
 package com.back.koreaTravelGuide.domain.userChat.chatroom.repository
 
 import com.back.koreaTravelGuide.domain.userChat.chatroom.entity.ChatRoom
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -19,4 +21,23 @@ interface ChatRoomRepository : JpaRepository<ChatRoom, Long> {
         guideId: Long,
         userId: Long,
     ): ChatRoom?
+
+    @Query(
+        """
+        select r from ChatRoom r
+        where (r.guideId = :memberId or r.userId = :memberId)
+          and (
+            :cursorUpdatedAt is null
+            or r.updatedAt < :cursorUpdatedAt
+            or (r.updatedAt = :cursorUpdatedAt and r.id < :cursorRoomId)
+          )
+        order by r.updatedAt desc, r.id desc
+        """,
+    )
+    fun findPagedByMember(
+        @Param("memberId") memberId: Long,
+        @Param("cursorUpdatedAt") cursorUpdatedAt: java.time.ZonedDateTime?,
+        @Param("cursorRoomId") cursorRoomId: Long?,
+        pageable: Pageable,
+    ): List<ChatRoom>
 }


### PR DESCRIPTION
- Added the listRooms GET endpoint so authenticated users can page through their chat rooms, handling limit and cursor parameters safely.
  - Implemented cursor-based pagination in the service layer, parsing the incoming cursor, querying the page, and constructing the next-cursor token for the response.
  - Extended the repository with a JPQL query that orders by updatedAt and id, applying cursor bounds to fetch a member’s chat rooms page by page.
  - Introduced the ChatRoomListResponse DTO to return the paged room data along with the next cursor value.
  - Expanded the controller integration test to seed multiple rooms and assert that sequential requests honor the cursor-driven pagination flow.
