### PR TITLE
fix: Remove feat/be/** from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,6 @@ on:
       - "Dockerfile"
     branches:
       - main
-      - feat/be/**
 permissions:
   contents: write # 태그/릴리즈
   packages: write # GHCR 푸시


### PR DESCRIPTION
Close #99 
## Summary
- deploy.yml에서 feature 브랜치 배포 트리거 제거
- main 브랜치에만 배포 실행되도록 수정

## Changes
- `branches:` 섹션에서 `- feat/be/**` 라인 삭제
- 이제 main 브랜치 푸시 시에만 배포 실행

## Test plan
- [ ] main 브랜치 푸시 시 배포 정상 실행 확인
- [ ] feature 브랜치 푸시 시 배포 미실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)