### PR TITLE
fix: Redis Repository 경고 해결 및 DB 스키마 초기화

### DIFF
--- a/src/main/kotlin/com/back/koreaTravelGuide/common/config/RedisConfig.kt
+++ b/src/main/kotlin/com/back/koreaTravelGuide/common/config/RedisConfig.kt
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.module.kotlin.KotlinModule
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.cache.RedisCacheConfiguration
@@ -17,12 +18,15 @@ import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.RedisSerializationContext
 import org.springframework.data.redis.serializer.StringRedisSerializer
 import java.time.Duration
 
 @Configuration
+@EnableCaching
+@EnableRedisRepositories(basePackages = ["nowhere"])
 class RedisConfig {
     @Value("\${spring.data.redis.host:localhost}")
     private lateinit var redisHost: String

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -9,7 +9,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
Close #103 
## Summary
- Redis Repository 스캔으로 인한 경고 로그 해결
- DB 스키마 초기화를 위한 임시 설정 변경

## Changes
- `RedisConfig`에 `@EnableCaching` 추가 (명시적 캐싱 활성화)
- `@EnableRedisRepositories(basePackages = ["nowhere"])` 추가하여 JPA Repository가 Redis Repository로 오인식되는 것 방지
- `application-prod.yml`의 `ddl-auto`를 임시로 `create`로 변경 (배포 후 `update`로 재변경 예정)

## Issue
- 배포 서버에서 6개의 JPA Repository가 Redis Repository로 오인식되어 경고 로그 발생
- `users.location` 컬럼 타입 변경 시 자동 캐스팅 실패로 인한 DDL 에러

## Test plan
- [x] 로컬에서 ktlint 체크 통과
- [ ] 배포 후 Redis Repository 경고 로그 사라지는지 확인
- [ ] DB 테이블 정상 생성 확인
- [ ] 이후 `ddl-auto: update`로 변경하여 재배포

🤖 Generated with [Claude Code](https://claude.com/claude-code)