### PR TITLE
fix: JPA Repository 설정 재적용 및 ddl-auto update 변경

### DIFF
--- a/src/main/kotlin/com/back/koreaTravelGuide/KoreaTravelGuideApplication.kt
+++ b/src/main/kotlin/com/back/koreaTravelGuide/KoreaTravelGuideApplication.kt
@@ -4,8 +4,10 @@ import io.github.cdimascio.dotenv.dotenv
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.cache.annotation.EnableCaching
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
 @EnableCaching
+@EnableJpaRepositories(basePackages = ["com.back.koreaTravelGuide.domain"])
 @SpringBootApplication(scanBasePackages = ["com.back.koreaTravelGuide"])
 class KoreaTravelGuideApplication
 

--- a/src/main/kotlin/com/back/koreaTravelGuide/common/config/RedisConfig.kt
+++ b/src/main/kotlin/com/back/koreaTravelGuide/common/config/RedisConfig.kt
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.module.kotlin.KotlinModule
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.cache.CacheManager
-import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.cache.RedisCacheConfiguration
@@ -18,15 +17,12 @@ import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.RedisSerializationContext
 import org.springframework.data.redis.serializer.StringRedisSerializer
 import java.time.Duration
 
 @Configuration
-@EnableCaching
-@EnableRedisRepositories(basePackages = ["nowhere"])
 class RedisConfig {
     @Value("\${spring.data.redis.host:localhost}")
     private lateinit var redisHost: String

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -9,7 +9,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## Summary
PR #109 머지로 인해 덮어씌워진 JPA Repository 설정을 재적용하고, ddl-auto를 update로 변경합니다.

## Changes
- `KoreaTravelGuideApplication`에 `@EnableJpaRepositories(basePackages = ["com.back.koreaTravelGuide.domain"])` 추가
- `RedisConfig`에서 중복된 `@EnableCaching`, `@EnableRedisRepositories` 제거
- `application-prod.yml`의 `ddl-auto`를 `create`에서 `update`로 변경

## Issue
- PR #107의 변경사항이 PR #109 머지 시 일부 덮어씌워짐
- Redis Repository 경고 로그가 다시 발생하는 문제 해결 필요
- DB 스키마 초기화 후 update 모드로 전환 필요

## Related PRs
- #107: 최초 수정 PR
- #109: 덮어쓴 PR

## Test plan
- [x] 로컬에서 ktlint 체크 통과
- [ ] 배포 후 Redis Repository 경고 로그 사라지는지 확인
- [ ] ddl-auto update 모드로 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)