### PR TITLE
fix: Redis Repository 경고 로그 완전 제거

### DIFF
--- a/src/main/kotlin/com/back/koreaTravelGuide/KoreaTravelGuideApplication.kt
+++ b/src/main/kotlin/com/back/koreaTravelGuide/KoreaTravelGuideApplication.kt
@@ -2,13 +2,17 @@ package com.back.koreaTravelGuide
 
 import io.github.cdimascio.dotenv.dotenv
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
 import org.springframework.boot.runApplication
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
 @EnableCaching
 @EnableJpaRepositories(basePackages = ["com.back.koreaTravelGuide.domain"])
-@SpringBootApplication(scanBasePackages = ["com.back.koreaTravelGuide"])
+@SpringBootApplication(
+    scanBasePackages = ["com.back.koreaTravelGuide"],
+    exclude = [RedisRepositoriesAutoConfiguration::class],
+)
 class KoreaTravelGuideApplication
 
 fun main(args: Array<String>) {


### PR DESCRIPTION
## Summary
Redis Repository 자동 설정을 완전히 비활성화하여 경고 로그를 제거합니다.

## Changes
- `@SpringBootApplication`에 `exclude = [RedisRepositoriesAutoConfiguration::class]` 추가
- JPA Repository가 Redis Repository로 스캔되는 것을 원천 차단

## Issue
- PR #110에서 `@EnableJpaRepositories`를 추가했지만 여전히 Redis Repository 스캔이 발생
- 6개의 경고 로그가 계속 발생

## Test plan
- [x] 로컬에서 ktlint 체크 통과
- [ ] 배포 후 Redis Repository 경고 로그 완전 제거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)