### PR TITLE
fix(be): stabilize room pagination ordering

### DIFF
--- a/src/test/kotlin/com/back/koreaTravelGuide/domain/userChat/chatroom/controller/ChatRoomControllerTest.kt
+++ b/src/test/kotlin/com/back/koreaTravelGuide/domain/userChat/chatroom/controller/ChatRoomControllerTest.kt
@@ -26,8 +26,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.transaction.annotation.Transactional
-import java.time.ZoneId
-import java.time.ZonedDateTime
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -95,7 +93,7 @@ class ChatRoomControllerTest {
     @Test
     @DisplayName("listRooms returns paginated rooms with cursor")
     fun listRoomsReturnsPaginatedRooms() {
-        val baseTime = ZonedDateTime.now(ZoneId.of("Asia/Seoul"))
+        val baseTime = existingRoom.updatedAt
         val extraRooms =
             (1..6).map { idx ->
                 val extraGuide =


### PR DESCRIPTION
- 기존 채팅방의 updatedAt을 기준 시각으로 사용
 - 페이징 결과의 첫 번째 방이 예상한 방과 일치하도록 보장
