### PR TITLE
feat(be): RabbitMQ 인프라 구성 및 개발 환경 개선 (#141)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,20 +4,26 @@ services:
   rabbit:
     image: rabbitmq:3-management       # 버전 명시 권장 (예: 3.13-management)
     container_name: rabbitmq-1
+    networks:
+      - common                          # 이미 존재하는 공용 네트워크 사용
     ports:
       - "5672:5672"     # AMQP (Spring ↔ RabbitMQ)
       - "61613:61613"   # STOMP (Relay가 여기에 붙음)
       - "15672:15672"   # Management UI (로컬에서만)
     environment:
+      TZ: Asia/Seoul                    # 타임존 설정
       RABBITMQ_DEFAULT_USER: admin
-      RABBITMQ_DEFAULT_PASS: admin
-    volumes:             # 영속화가 필요할 때만 유지
-      - ./dockerProjects/rabbitmq-1/volumes/etc/rabbitmq:/etc/rabbitmq
-      - ./dockerProjects/rabbitmq-1/volumes/var/lib/rabbitmq:/var/lib/rabbitmq
-      - ./dockerProjects/rabbitmq-1/volumes/var/log/rabbitmq:/var/log/rabbitmq
+      RABBITMQ_DEFAULT_PASS: "$PASSWORD_1"
+    volumes:
+      - ./volumes/etc/rabbitmq:/etc/rabbitmq
+      - ./volumes/var/lib/rabbitmq:/var/lib/rabbitmq
+      - ./volumes/var/log/rabbitmq:/var/log/rabbitmq
     command: >
       sh -c "
         rabbitmq-plugins enable rabbitmq_management &&
         rabbitmq-plugins enable rabbitmq_stomp &&
         rabbitmq-server
       "
+networks:
+  common:
+    external: true                      # 이미 만들어진 네트워크를 사용

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -263,33 +263,55 @@ CREATE DATABASE \"${var.app_1_db_name}\" OWNER team11;
 GRANT ALL PRIVILEGES ON DATABASE \"${var.app_1_db_name}\" TO team11;
 "
 
-# rabbitmq 설치
-docker run -d \
-  --name rabbitmq_1 \
-  --restart unless-stopped \
-  --network common \
-  -p 5672:5672 \
-  -p 61613:61613 \
-  -p 15672:15672 \
-  -e RABBITMQ_DEFAULT_USER=admin \
-  -e RABBITMQ_DEFAULT_PASS=${var.password_1} \
-  -e TZ=Asia/Seoul \
-  -v /dockerProjects/rabbitmq_1/volumes/data:/var/lib/rabbitmq \
-  rabbitmq:3-management
+# docker-compose 설치
+echo "docker-compose 설치 중..."
+curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+ln -sf /usr/local/bin/docker-compose /usr/bin/docker-compose
+docker-compose --version
 
-# RabbitMQ가 준비될 때까지 대기
-echo "RabbitMQ가 기동될 때까지 대기 중..."
-until docker exec rabbitmq_1 rabbitmqctl status &> /dev/null; do
-  echo "RabbitMQ가 아직 준비되지 않음. 5초 후 재시도..."
-  sleep 5
-done
-echo "RabbitMQ가 준비됨. STOMP 플러그인 활성화 중..."
+# RabbitMQ docker-compose.yml 생성
+mkdir -p /dockerProjects/rabbitmq_1
+cat > /dockerProjects/rabbitmq_1/docker-compose.yml <<'RABBITMQ_COMPOSE'
+version: "3.8"
 
-# RabbitMQ STOMP 플러그인 활성화
-docker exec rabbitmq_1 rabbitmq-plugins enable rabbitmq_stomp
-docker exec rabbitmq_1 rabbitmq-plugins enable rabbitmq_management
+services:
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: rabbitmq_1
+    restart: unless-stopped
+    networks:
+      - common
+    ports:
+      - "5672:5672"
+      - "61613:61613"
+      - "15672:15672"
+    environment:
+      TZ: Asia/Seoul
+      RABBITMQ_DEFAULT_USER: admin
+      RABBITMQ_DEFAULT_PASS: \${PASSWORD_1}
+    volumes:
+      - /dockerProjects/rabbitmq_1/volumes/etc/rabbitmq:/etc/rabbitmq
+      - /dockerProjects/rabbitmq_1/volumes/var/lib/rabbitmq:/var/lib/rabbitmq
+      - /dockerProjects/rabbitmq_1/volumes/var/log/rabbitmq:/var/log/rabbitmq
+    command: >
+      sh -c "
+        rabbitmq-plugins enable rabbitmq_management &&
+        rabbitmq-plugins enable rabbitmq_stomp &&
+        rabbitmq-server
+      "
 
-echo "RabbitMQ 설치 및 설정 완료!"
+networks:
+  common:
+    external: true
+RABBITMQ_COMPOSE
+
+# RabbitMQ 시작
+echo "RabbitMQ 시작 중..."
+cd /dockerProjects/rabbitmq_1
+docker-compose up -d
+
+echo "RabbitMQ docker-compose 설치 완료!"
 
 echo "${var.github_access_token_1}" | docker login ghcr.io -u ${var.github_access_token_1_owner} --password-stdin
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -210,6 +210,13 @@ yum install docker -y
 systemctl enable docker
 systemctl start docker
 
+# docker-compose 설치
+echo "docker-compose 설치 중..."
+curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+ln -sf /usr/local/bin/docker-compose /usr/bin/docker-compose
+docker-compose --version
+
 # 도커 네트워크 생성
 docker network create common
 
@@ -262,13 +269,6 @@ CREATE USER team11 WITH PASSWORD '${var.password_1}';
 CREATE DATABASE \"${var.app_1_db_name}\" OWNER team11;
 GRANT ALL PRIVILEGES ON DATABASE \"${var.app_1_db_name}\" TO team11;
 "
-
-# docker-compose 설치
-echo "docker-compose 설치 중..."
-curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-chmod +x /usr/local/bin/docker-compose
-ln -sf /usr/local/bin/docker-compose /usr/bin/docker-compose
-docker-compose --version
 
 # RabbitMQ docker-compose.yml 생성
 mkdir -p /dockerProjects/rabbitmq_1

--- a/infra/rabbitmq-docker-compose.yml
+++ b/infra/rabbitmq-docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.8"
+
+services:
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: rabbitmq_1
+    restart: unless-stopped
+    networks:
+      - common
+    ports:
+      - "5672:5672"
+      - "61613:61613"
+      - "15672:15672"
+    environment:
+      TZ: Asia/Seoul
+      RABBITMQ_DEFAULT_USER: admin
+      RABBITMQ_DEFAULT_PASS: ${PASSWORD_1}
+    volumes:
+      - /dockerProjects/rabbitmq_1/volumes/etc/rabbitmq:/etc/rabbitmq
+      - /dockerProjects/rabbitmq_1/volumes/var/lib/rabbitmq:/var/lib/rabbitmq
+      - /dockerProjects/rabbitmq_1/volumes/var/log/rabbitmq:/var/log/rabbitmq
+    command: >
+      sh -c "
+        rabbitmq-plugins enable rabbitmq_management &&
+        rabbitmq-plugins enable rabbitmq_stomp &&
+        rabbitmq-server
+      "
+
+networks:
+  common:
+    external: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,7 @@ spring:
     exclude:
       - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration # Redis 없어도 실행 가능하도록 변경
       - org.springframework.boot.autoconfigure.session.SessionAutoConfiguration # Redis 없어도 실행 가능하도록 변경
+      - org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration # RabbitMQ 없어도 실행 가능하도록 변경 (dev용)
   config:
     import: 
       - "optional:file:.env[.properties]"


### PR DESCRIPTION
## 작업 내용

### 1. RabbitMQ 인프라 구성
- **로컬 개발 환경**: docker-compose.yml 추가
  - RabbitMQ 3-management 이미지 사용
  - STOMP 플러그인 활성화 (WebSocket 지원)
  - Management UI 포트: 15672
- **EC2 운영 환경**: Terraform 설정 추가
  - infra/rabbitmq-docker-compose.yml 템플릿 생성
  - main.tf에 RabbitMQ 컨테이너 배포 로직 추가
  - docker-compose 설치 순서 최적화 (Docker → docker-compose → 컨테이너)

### 2. 개발 환경 설정 개선
- **application.yml**: dev 프로파일에서 RabbitMQ 자동 구성 제외
  - RabbitAutoConfiguration 비활성화
  - 로컬 개발 시 RabbitMQ 없이도 서버 실행 가능
  - Health Check UP 상태 유지
- **더미 데이터**: DevConfig에 가이드 2명 자동 생성
  - 서울 가이드, 부산 사하구 가이드
  - 중복 방지 로직 포함

### 3. 문서화
- **CLAUDE.md**: 프로젝트 문서 대폭 업데이트
  - RabbitMQ 통합 가이드 추가
  - Profile-based 설정 전략 설명
  - 인프라 & 배포 섹션 추가
  - WebSocket & 실시간 메시징 아키텍처 문서화
  - 트러블슈팅 섹션 확장

## 기술적 변경사항

### 아키텍처
```
개발 환경 (dev):
- SimpleBroker (in-memory)
- RabbitMQ 불필요
- H2 데이터베이스

운영 환경 (prod):
- RabbitMQ STOMP Relay
- RabbitMQ 필수
- PostgreSQL 데이터베이스
```

### 주요 파일
- `docker-compose.yml`: 로컬 RabbitMQ 환경
- `infra/main.tf`: EC2 인프라 자동화
- `infra/rabbitmq-docker-compose.yml`: EC2용 템플릿
- `application.yml`: dev 환경 RabbitMQ 제외 설정
- `CLAUDE.md`: 프로젝트 문서

## 테스트 방법

### 로컬 개발
```bash
# RabbitMQ 없이 서버 실행
./gradlew bootRun

# Health Check
curl http://localhost:8080/actuator/health
# 결과: {"status":"UP"}
```

### RabbitMQ 테스트
```bash
# RabbitMQ 시작
docker network create common
docker-compose up -d

# 서버 실행 (prod 프로파일)
./gradlew bootRun --args='--spring.profiles.active=prod'
```

## 주의사항

1. **EC2 배포 전 수동 설정 필요**
   - EC2에서 `docker network create common` 실행
   - RabbitMQ 컨테이너 시작 확인

2. **환경변수 추가**
   - GitHub Secrets에 RabbitMQ 환경변수 추가 필요
   - RABBITMQ_HOST, RABBITMQ_PORT, RABBITMQ_USERNAME, RABBITMQ_PASSWORD, RABBITMQ_STOMP_PORT

3. **.gitignore 변경**
   - docker-compose.yml 추적하도록 변경 (팀 공유)

## 관련 이슈
Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)